### PR TITLE
chore: Release 1.4.0 — Gradle 9.1 / AGP 9.0.1 / Kotlin 2.3.20 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.0
+
+- Upgraded the Android build toolchain to Gradle `9.1`, Android Gradle Plugin `9.0.1`, and Kotlin `2.3.20`.
+- Replaced the deprecated `kotlinOptions` block with the modern `kotlin { compilerOptions }` DSL across the plugin and example app.
+
 ## 1.3.7
 
 - Re-generated android plugin files to be compatible with the latest version of Flutter.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Upgraded the Android build toolchain to Gradle `9.1`, Android Gradle Plugin `9.0.1`, and Kotlin `2.3.20`.
 - Replaced the deprecated `kotlinOptions` block with the modern `kotlin { compilerOptions }` DSL across the plugin and example app.
+- Bumped the `bluez` dependency to `^0.8.3`.
 
 ## 1.3.7
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,14 +2,14 @@ group = "com.layrz.layrz_ble"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    val kotlinVersion = "2.2.20"
+    val kotlinVersion = "2.3.20"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:8.11.1")
+        classpath("com.android.tools.build:gradle:9.0.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }
@@ -23,7 +23,6 @@ allprojects {
 
 plugins {
     id("com.android.library")
-    id("kotlin-android")
 }
 
 android {
@@ -34,10 +33,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     sourceSets {
@@ -67,6 +62,12 @@ android {
                 }
             }
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("com.android.application")
-    id("kotlin-android")
     // The Flutter Gradle Plugin must be applied after the Android and Kotlin Gradle plugins.
     id("dev.flutter.flutter-gradle-plugin")
 }
@@ -13,10 +12,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
     }
 
     defaultConfig {
@@ -36,6 +31,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx8G -XX:MaxMetaspaceSize=4G -XX:ReservedCodeCacheSize=512m -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This newDsl flag was added by the Flutter template
+android.newDsl=false
+# This builtInKotlin flag was added by the Flutter template
+android.builtInKotlin=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
-    id("com.android.application") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("com.android.application") version "9.0.1" apply false
+    id("org.jetbrains.kotlin.android") version "2.3.20" apply false
 }
 
 include(":app")

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.7"
+    version: "1.4.0"
   layrz_icons:
     dependency: "direct main"
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.6"
+    version: "1.3.7"
   layrz_icons:
     dependency: "direct main"
     description:
@@ -531,10 +531,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -904,10 +904,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   two_dimensional_scrollables:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   collection: ^1.18.0
   layrz_models: ^3.4.0
   flutter_web_bluetooth: ^1.0.0
-  bluez: ^0.8.2
+  bluez: ^0.8.3
   freezed_annotation: ^3.0.0
   json_annotation: ^4.9.0
   meta: ^1.17.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_ble
 description: "A Flutter library for cross-platform Bluetooth Low Energy (BLE) communication, supporting Android, iOS, macOS, Windows, Linux, and web."
-version: 1.3.7
+version: 1.4.0
 repository: https://github.com/goldenm-software/layrz_ble
 
 keywords:


### PR DESCRIPTION
## 📋 Summary

- Release `1.4.0`.
- Upgrades the Android build toolchain and modernizes the Kotlin Gradle DSL across the plugin and example app.

## 📝 Changes

### 🔧 Chore / Config
- Upgraded to Gradle `9.1`, Android Gradle Plugin `9.0.1`, and Kotlin `2.3.20`.
- Migrated from the deprecated `kotlinOptions` block to the modern `kotlin { compilerOptions }` DSL.
- Dropped the redundant `kotlin-android` plugin id and added the `newDsl`/`builtInKotlin` template flags.
- Bumped `pubspec.yaml` to `1.4.0` and updated `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)