### PR TITLE
fix(android): correct BLE scan latency and unhandled scan failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.4.1
+
+- Fixed Android BLE scanning being significantly slower than other apps (e.g. nRF Connect) at discovering devices: `SCAN_MODE_LOW_LATENCY` was left commented out in `composeSettings()`, leaving scans on the default `SCAN_MODE_LOW_POWER` duty-cycled mode.
+- Fixed Android scans getting silently stuck: `ScanCallback.onScanFailed` was never overridden, so an OS-level scan failure (throttling, `SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES`, etc.) left the plugin believing it was still scanning forever, with no way for the Dart side to recover. `startScan()`/`stopScan()` on Android now also emit `onScanStarted`/`onScanStopped` on their normal success paths for full scan lifecycle visibility from Dart.
+
 ## 1.4.0
 
 - Upgraded the Android build toolchain to Gradle `9.1`, Android Gradle Plugin `9.0.1`, and Kotlin `2.3.20`.

--- a/README.md
+++ b/README.md
@@ -335,6 +335,26 @@ All packages developed by [Layrz](https://layrz.com) are prefixed with `layrz_`,
 ### I have a question, how can I contact you?
 If you need more assistance, you open an issue on the [Repository](https://github.com/goldenm-software/layrz_ble) and we're happy to help you :)
 
+## Release process (maintainers)
+Publishing to pub.dev is fully automated through GitHub Actions (`.github/workflows/publish.yaml`) — there is no manual `dart pub publish` step, and no publish token is stored in the repo; the workflow authenticates to pub.dev via [Trusted Publishing (OIDC)](https://dart.dev/tools/pub/automated-publishing), configured once on the package's pub.dev admin page.
+
+To ship a new version:
+
+1. Merge your changes into `main` (via PR from `development`). Bump the `version:` field in `pubspec.yaml` and add a matching entry at the top of `CHANGELOG.md` as part of that PR.
+   - Follow semver: PATCH (`x.y.Z`) for bug fixes/behavior corrections with no public API change, MINOR (`x.Y.0`) for backwards-compatible additions (new methods, new platform support, tooling upgrades), MAJOR (`X.0.0`) for breaking changes to the public Dart API.
+2. Once merged, create and push a tag matching the new version, prefixed with `v` (e.g. `v1.4.1`), pointing at that commit on `main`:
+   ```bash
+   git checkout main
+   git pull
+   git tag v1.4.1
+   git push origin v1.4.1
+   ```
+3. Pushing the tag triggers `publish.yaml`:
+   - Validates the tag format (`vX.Y.Z`) and that it points at a commit already on `main`.
+   - Runs `flutter analyze` and a `flutter pub publish --dry-run`, then publishes for real with `flutter pub publish --force`.
+   - On success, auto-generates a GitHub Release with a changelog built from the commit history.
+   - On failure, the tag is renamed to `failed-vX.Y.Z-<timestamp>` and removed so you can fix the issue and re-tag.
+
 ## License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 

--- a/android/src/main/kotlin/com/layrz/layrz_ble/LayrzBlePlugin.kt
+++ b/android/src/main/kotlin/com/layrz/layrz_ble/LayrzBlePlugin.kt
@@ -237,6 +237,9 @@ class LayrzBlePlugin : LayrzBlePlatformChannel, FlutterPlugin, ActivityAware, Pl
 
 		isScanning = true
 		Log.d(TAG, "Started scanning")
+		mainLooper?.post {
+			callbackChannel?.onScanStarted {}
+		}
 		callback(Result.success(true))
 		return
 	}
@@ -271,6 +274,9 @@ class LayrzBlePlugin : LayrzBlePlatformChannel, FlutterPlugin, ActivityAware, Pl
 			isScanning = false
 			Log.d(TAG, "Stopped scanning")
 			macFilter = null
+			mainLooper?.post {
+				callbackChannel?.onScanStopped {}
+			}
 		}
 
 		callback(Result.success(true))
@@ -1107,6 +1113,20 @@ class LayrzBlePlugin : LayrzBlePlatformChannel, FlutterPlugin, ActivityAware, Pl
 
 			devices[macAddress] = device
 		}
+
+		override fun onScanFailed(errorCode: Int) {
+			super.onScanFailed(errorCode)
+			// The OS can refuse/kill a scan after it was accepted (e.g. throttling
+			// after too many start/stop calls in a short window, or
+			// SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES). Without this, `isScanning`
+			// stays true forever, startScan() becomes a permanent no-op, and no
+			// error ever reaches Dart - the app just looks stuck.
+			Log.w(TAG, "Scan failed with error code: $errorCode")
+			isScanning = false
+			mainLooper?.post {
+				callbackChannel?.onScanStopped {}
+			}
+		}
 	}
 
 	private var gattCallback = object : BluetoothGattCallback() {
@@ -1530,7 +1550,7 @@ class LayrzBlePlugin : LayrzBlePlatformChannel, FlutterPlugin, ActivityAware, Pl
 
 	private fun composeSettings(adapter: BluetoothAdapter): ScanSettings.Builder {
 		val settings = ScanSettings.Builder()
-		// settings.setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
+		settings.setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
 		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && adapter.isLeExtendedAdvertisingSupported) {
 			Log.d(TAG, "Bluetooth 5.0 supported, using extended advertising")
 			settings.setLegacy(false)

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.0"
+    version: "1.4.1"
   layrz_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_ble
 description: "A Flutter library for cross-platform Bluetooth Low Energy (BLE) communication, supporting Android, iOS, macOS, Windows, Linux, and web."
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/goldenm-software/layrz_ble
 
 keywords:


### PR DESCRIPTION
## 📋 Summary

- Fixes Android BLE scanning being significantly slower than other apps at discovering devices
- Fixes scans getting silently stuck when the OS fails a scan at the platform level
- Bumps version to 1.4.1 and documents the release process for maintainers

## 📝 Changes

### 🐛 Fixes
- `SCAN_MODE_LOW_LATENCY` was left commented out in `composeSettings()`, leaving scans on the default `SCAN_MODE_LOW_POWER` duty-cycled mode — now enabled.
- `ScanCallback.onScanFailed` was never overridden, so an OS-level scan failure (throttling, `SCAN_FAILED_OUT_OF_HARDWARE_RESOURCES`, etc.) left the plugin believing it was still scanning forever. `startScan()`/`stopScan()` now also emit `onScanStarted`/`onScanStopped` on their normal success paths for full scan lifecycle visibility from Dart.

### 📚 Docs
- Documented the maintainer release process (tagging, Trusted Publishing via GitHub Actions) in the README.

### 🔧 Chore / Config
- Bumped `pubspec.yaml` version to `1.4.1` and added the corresponding `CHANGELOG.md` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)