### PR TITLE
fix(windows): receive Bluetooth 5 extended advertisements (v1.4.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.2
+
+- Fixed Windows never reporting peripherals that advertise with Bluetooth 5 extended advertising PDUs: `BluetoothLEAdvertisementWatcher` only delivers legacy advertisements unless `AllowExtendedAdvertisements` is set, so those devices were dropped in the native layer and never reached Dart — no scan result, no error, as if they were not there. Android already opted in via `setLegacy(false)`/`PHY_LE_ALL_SUPPORTED` and CoreBluetooth needs no opt-in, leaving Windows as the only affected platform.
+- The opt-in is guarded: on adapters or Windows builds without extended advertising support the setter throws, and the watcher falls back to legacy-only scanning as before. Legacy (Bluetooth 4.x) discovery is unaffected either way, since the extended scanner also covers the primary advertising channels.
+- `IsExtendedAdvertisingSupported()` was already queried and logged in `GetRadiosAsync()` but never wired to the watcher; that detection is now meaningful.
+
 ## 1.4.1
 
 - Fixed Android BLE scanning being significantly slower than other apps (e.g. nRF Connect) at discovering devices: `SCAN_MODE_LOW_LATENCY` was left commented out in `composeSettings()`, leaving scans on the default `SCAN_MODE_LOW_POWER` duty-cycled mode.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -406,7 +406,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.1"
+    version: "1.4.2"
   layrz_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_ble
 description: "A Flutter library for cross-platform Bluetooth Low Energy (BLE) communication, supporting Android, iOS, macOS, Windows, Linux, and web."
-version: 1.4.1
+version: 1.4.2
 repository: https://github.com/goldenm-software/layrz_ble
 
 keywords:

--- a/windows/src/layrz_ble_plugin.cpp
+++ b/windows/src/layrz_ble_plugin.cpp
@@ -927,6 +927,20 @@ namespace layrz_ble {
     if (leScanner == nullptr) {
       leScanner = BluetoothLEAdvertisementWatcher();
       leScanner.ScanningMode(BluetoothLEScanningMode::Active);
+
+      // Without this, the watcher only reports legacy advertisements: any peripheral
+      // using Bluetooth 5 extended advertising PDUs is silently dropped and never
+      // reaches Dart. Android already opts in via setLegacy(false)/PHY_LE_ALL_SUPPORTED
+      // and CoreBluetooth needs no opt-in, so Windows was the odd one out.
+      //
+      // The setter throws on adapters or OS builds without extended advertising
+      // support, where falling back to legacy-only is the correct behaviour.
+      try {
+        leScanner.AllowExtendedAdvertisements(true);
+        Log("Extended advertisements enabled on the LE scanner");
+      } catch (...) {
+        Log("Extended advertisements not supported, scanning legacy advertisements only");
+      }
       // Subscribe to the Received event
       leScanner.Received([this](BluetoothLEAdvertisementWatcher const&, BluetoothLEAdvertisementReceivedEventArgs const& args) {
         auto macAddress = toUppercase(formatBluetoothAddress(args.BluetoothAddress()));


### PR DESCRIPTION
## Summary

On Windows, peripherals that advertise with Bluetooth 5 extended advertising PDUs were **never delivered to Dart at all** — no scan result, no error, as if the device were not present. `BluetoothLEAdvertisementWatcher` only reports legacy advertisements unless `AllowExtendedAdvertisements` is set, and `setupWatcher()` only set `ScanningMode(Active)`.

Android already opted in correctly via `setLegacy(false)` + `PHY_LE_ALL_SUPPORTED`, and CoreBluetooth needs no opt-in, so Windows was the only affected platform. The signature of the bug is a device that a phone can see but the Windows app cannot.

Curiously, `adapter.IsExtendedAdvertisingSupported()` was already queried and logged as `"Bluetooth 5.X supported!"` in `GetRadiosAsync()` — but that detection was dead code, never wired to the watcher.

## Does this affect Bluetooth 4.x?

No. The flag is additive: the extended scanner also covers the primary advertising channels where legacy devices broadcast, and the `Received` handler does not discriminate by PDU type or `IsScanResponse`/`IsConnectable`. Connection is untouched — the flag is a watcher property and `connect()` goes through address → `BluetoothLEDevice` → GATT without reading it.

The setter is wrapped in `try/catch` because it throws on adapters or Windows builds without extended advertising support, where legacy-only scanning is the correct fallback. Worst case is exactly today's behaviour, never worse. It is set at watcher construction, before `Start()`, since the property cannot be changed on a running watcher.

## Verification

Confirmed on hardware: a Layrz BLEfier 2 configured for BLE 5 advertising, previously invisible on Windows, is now discovered and decoded correctly. Legacy devices in range (BLEfier 1, ELA Puck DI/PIR, iBeacon, Eddystone) continue to be discovered.

## Release

Bumps `version:` to `1.4.2` (PATCH — behaviour correction, no public API change) with a matching `CHANGELOG.md` entry, per the release process in the README. **Do not merge yet** — pending review by another member of the organization. The `v1.4.2` tag should be pushed only after this lands on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)